### PR TITLE
use lineWidth to check x's validity on deleteRune function

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -327,7 +327,7 @@ func (v *View) deleteRune(x, y int) (int, error) {
 		return 0, err
 	}
 
-	if x < 0 || y < 0 || y >= len(v.lines) || x >= len(v.lines[y]) {
+	if x < 0 || y < 0 || y >= len(v.lines) || x >= lineWidth(v.lines[y]) {
 		return 0, errors.New("invalid point")
 	}
 


### PR DESCRIPTION
Hello!

I found that Backspace while editing (using defaultEditor) sometimes doesn't work if the line includes wide charactor even the cursor position seems valid.I guess the validation for cursor `x` and `v.lines[y]` in `deleteRune` function should use `lineWidth` function.

Here's patch. Could you please check them and accept if it looks good :)
Thanks!