### PR TITLE
Added `╴` and `╶` to the side of boxes when 1 height

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -561,6 +561,14 @@ func corner(v *View, directions byte) rune {
 // drawFrameCorners draws the corners of the view.
 func (g *Gui) drawFrameCorners(v *View, fgColor, bgColor Attribute) error {
 	if v.y0 == v.y1 {
+		if !g.SupportOverlaps {
+			if err := g.SetRune(v.x0, v.y0, '╶', fgColor, bgColor); err != nil {
+				return err
+			}
+			if err := g.SetRune(v.x1, v.y0, '╴', fgColor, bgColor); err != nil {
+				return err
+			}
+		}
 		return nil
 	}
 


### PR DESCRIPTION
Visually this looks just a bit better,  
Now the 1 line boxes have the same width as the normal boxes.
![image](https://user-images.githubusercontent.com/15320763/56849168-6f95b500-68f1-11e9-8b15-cb464013244a.png)

See https://github.com/jesseduffield/lazygit/pull/441#issuecomment-487065334 for more information