### PR TITLE
Fix lazygit small size panics

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -733,7 +733,7 @@ func (g *Gui) execKeybindings(v *View, ev *termbox.Event) (matched bool, err err
 		if kb.matchView(v) {
 			return g.execKeybinding(v, kb)
 		}
-		if kb.viewName == "" && (!v.Editable || kb.ch == 0) {
+		if kb.viewName == "" && ((v != nil && !v.Editable) || kb.ch == 0) {
 			globalKb = kb
 		}
 	}

--- a/gui.go
+++ b/gui.go
@@ -151,7 +151,7 @@ func (g *Gui) Rune(x, y int) (rune, error) {
 // ErrUnknownView is returned, which allows to assert if the View must
 // be initialized. It checks if the position is valid.
 func (g *Gui) SetView(name string, x0, y0, x1, y1 int, overlaps byte) (*View, error) {
-	if x0 >= x1 || y0 >= y1 {
+	if x0 >= x1 {
 		return nil, errors.New("invalid dimensions")
 	}
 	if name == "" {
@@ -471,6 +471,9 @@ func (g *Gui) flush() error {
 		}
 	}
 	for _, v := range g.views {
+		if v.y1 < v.y0 {
+			continue
+		}
 		if v.Frame {
 			var fgColor, bgColor Attribute
 			if g.Highlight && v == g.currentView {
@@ -557,6 +560,10 @@ func corner(v *View, directions byte) rune {
 
 // drawFrameCorners draws the corners of the view.
 func (g *Gui) drawFrameCorners(v *View, fgColor, bgColor Attribute) error {
+	if v.y0 == v.y1 {
+		return nil
+	}
+
 	runeTL, runeTR, runeBL, runeBR := '┌', '┐', '└', '┘'
 	if g.SupportOverlaps {
 		runeTL = corner(v, BOTTOM|RIGHT)

--- a/gui.go
+++ b/gui.go
@@ -572,7 +572,7 @@ func corner(v *View, directions byte) rune {
 // drawFrameCorners draws the corners of the view.
 func (g *Gui) drawFrameCorners(v *View, fgColor, bgColor Attribute) error {
 	if v.y0 == v.y1 {
-		if !g.SupportOverlaps {
+		if !g.SupportOverlaps && v.x0 >= 0 && v.x1 >= 0 && v.y0 >= 0 && v.x0 < g.maxX && v.x1 < g.maxX && v.y0 < g.maxY {
 			if err := g.SetRune(v.x0, v.y0, '╶', fgColor, bgColor); err != nil {
 				return err
 			}

--- a/keybinding.go
+++ b/keybinding.go
@@ -35,10 +35,13 @@ func (kb *keybinding) matchKeypress(key Key, ch rune, mod Modifier) bool {
 // matchView returns if the keybinding matches the current view.
 func (kb *keybinding) matchView(v *View) bool {
 	// if the user is typing in a field, ignore char keys
+	if v == nil {
+		return false
+	}
 	if v.Editable == true && kb.ch != 0 {
 		return false
 	}
-	return v != nil && kb.viewName == v.name
+	return kb.viewName == v.name
 }
 
 // Key represents special keys or keys combinations.


### PR DESCRIPTION
This PR is made after a comment from you on: https://github.com/jesseduffield/lazygit/pull/441  
This PR solves: 
- `*errors.errorString` when resizing lg to a supper small size
- `panic: runtime error: invalid memory address or nil pointer dereference` when lazygit never renders UI only the to small box and someone presses a key