### PR TITLE
prompt sample to reproduce panic

### DIFF
--- a/_examples/prompt.go
+++ b/_examples/prompt.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"log"
+
+	"github.com/jesseduffield/gocui"
+)
+
+func main() {
+
+	g, err := gocui.NewGui(gocui.OutputNormal, true, gocui.NORMAL, false)
+	g.Cursor = true
+	if err != nil {
+		log.Panicln(err)
+	}
+	defer g.Close()
+
+	g.SetManagerFunc(layout)
+
+	if err := g.SetKeybinding("", nil, gocui.KeyCtrlC, gocui.ModNone, quit); err != nil {
+		log.Panicln(err)
+	}
+
+	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+		log.Panicln(err)
+	}
+
+}
+
+func quit(g *gocui.Gui, v *gocui.View) error {
+	return gocui.ErrQuit
+}
+
+func layout(g *gocui.Gui) error {
+	if v, err := g.SetView("prompt", 0, 0, 10, 3, 0); err != nil {
+		if !gocui.IsUnknownView(err) {
+			return err
+		}
+		v.Title = "prompt"
+		v.Editable = true
+		v.Wrap = true
+		_, err := g.SetCurrentView(v.Name())
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
_examples/prompt.go to reproduce panic on delete last empty line
It's a small prompt view. To reproduce panic insert any text, then newline and backspace to delete new empty line.
The reason is mergeLines clears viewLines to nil so code @ line edit.go:179 will panic

v.mergeLines(v.cy - 1) // set viewLines to nil
if len(v.viewLines[y-1].line) < maxPrevWidth { // read nil viewLines