### PR TITLE
Fix rendering of view titles containing multi-byte char

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/gdamore/tcell/v2"
 	"github.com/go-errors/errors"
+	"github.com/mattn/go-runewidth"
 )
 
 // OutputMode represents an output mode, which determines how colors
@@ -921,8 +922,8 @@ func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 
 	str := strings.Join(tabs, separator)
 
+	x := v.x0 + 2
 	for i, ch := range str {
-		x := v.x0 + i + 2
 		if x < 0 {
 			continue
 		} else if x > v.x1-2 || x >= g.maxX {
@@ -948,6 +949,7 @@ func (g *Gui) drawTitle(v *View, fgColor, bgColor Attribute) error {
 		if err := g.SetRune(x, v.y0, ch, currentFgColor, currentBgColor); err != nil {
 			return err
 		}
+		x += runewidth.RuneWidth(ch)
 	}
 	return nil
 }
@@ -962,14 +964,15 @@ func (g *Gui) drawSubtitle(v *View, fgColor, bgColor Attribute) error {
 	if start < v.x0 {
 		return nil
 	}
-	for i, ch := range v.Subtitle {
-		x := start + i
+	x := start
+	for _, ch := range v.Subtitle {
 		if x >= v.x1 {
 			break
 		}
 		if err := g.SetRune(x, v.y0, ch, fgColor, bgColor); err != nil {
 			return err
 		}
+		x += runewidth.RuneWidth(ch)
 	}
 	return nil
 }
@@ -990,14 +993,15 @@ func (g *Gui) drawListFooter(v *View, fgColor, bgColor Attribute) error {
 	if start < v.x0 {
 		return nil
 	}
-	for i, ch := range message {
-		x := start + i
+	x := start
+	for _, ch := range message {
 		if x >= v.x1 {
 			break
 		}
 		if err := g.SetRune(x, v.y1, ch, fgColor, bgColor); err != nil {
 			return err
 		}
+		x += runewidth.RuneWidth(ch)
 	}
 	return nil
 }


### PR DESCRIPTION
`LANG=zh lazygit`

|  | before | after  |
|--|--------|--------|
|stash and commands| <img width="1606" alt="スクリーンショット 2021-08-18 22 04 36" src="https://user-images.githubusercontent.com/10097437/129903404-4abd8ee2-c7fc-4c0c-a713-f1b18a13df2e.png">|<img width="1609" alt="スクリーンショット 2021-08-18 22 07 04" src="https://user-images.githubusercontent.com/10097437/129903483-2a35d731-cdbe-4ef9-b402-af956e0badc2.png">|
|commit message| <img width="198" alt="スクリーンショット 2021-08-18 22 04 44" src="https://user-images.githubusercontent.com/10097437/129903548-a6aaa1ef-f145-4e24-9d3b-08831b9e93e7.png"> |<img width="210" alt="スクリーンショット 2021-08-18 22 04 08" src="https://user-images.githubusercontent.com/10097437/129903562-7e6c5c1f-2014-4522-b6d9-2f1709ad1d92.png">|

```go
for i, ch := range str {
```

When we write ↑, `i` is the byte position of `ch` at UTF-8. And many Chinese characters are 3 bytes (Japanese too).