### PR TITLE
Fix an issue where long inputs containing wide characters cause blank spaces on the right side.

### DIFF
--- a/view.go
+++ b/view.go
@@ -936,11 +936,14 @@ func (v *View) draw() error {
 		if y >= maxY {
 			break
 		}
-		x := 0
+		x := -v.ox
 		j := 0
 		var c cell
 		for {
-			if j < v.ox {
+			if x < 0 {
+				if j < len(vline.line) {
+					x += runewidth.RuneWidth(vline.line[j].chr)
+				}
 				j++
 				continue
 			}


### PR DESCRIPTION
The cursor shifts by the number of wide characters off the screen.

<table>
<tr>
	<th>action
	<th>before (awesome)
	<th>after
<tr>
	<th>-
	<td><img width="530" alt="スクリーンショット 2021-10-30 22 15 40" src="https://user-images.githubusercontent.com/10097437/139534321-e7914a9e-b04c-48a0-b60d-a0defb446ec2.png">
	<td>
<img width="532" alt="スクリーンショット 2021-10-30 22 16 47" src="https://user-images.githubusercontent.com/10097437/139534328-54e95bbc-17ce-4501-8767-d77c5d454e20.png">

<tr>
	<th>type "a"
	<td>
<img width="533" alt="スクリーンショット 2021-10-30 22 15 49" src="https://user-images.githubusercontent.com/10097437/139534335-75191b8d-7fe3-43ca-9e89-7878369823ea.png">
	<td>
<img width="530" alt="スクリーンショット 2021-10-30 22 17 17" src="https://user-images.githubusercontent.com/10097437/139534346-e6a838de-fb31-442c-b4a4-35f3e16df52c.png">
<tr>
	<th>type "b"
	<td>
<img width="533" alt="スクリーンショット 2021-10-30 22 15 57" src="https://user-images.githubusercontent.com/10097437/139534364-9b715787-f28b-4b76-b432-c3b2a6425a88.png">
	<td>
<img width="534" alt="スクリーンショット 2021-10-30 22 17 24" src="https://user-images.githubusercontent.com/10097437/139534367-3cc4df16-89b2-40de-aeb2-b6b0280fbde5.png">

<tr>
	<th>type "c"
	<td>
<img width="533" alt="スクリーンショット 2021-10-30 22 16 06" src="https://user-images.githubusercontent.com/10097437/139534372-a9d825c0-d3db-4303-97d8-9717df654a0b.png">
	<td>
<img width="535" alt="スクリーンショット 2021-10-30 22 17 32" src="https://user-images.githubusercontent.com/10097437/139534375-db08580e-56cb-4c27-bba9-d637431f25d5.png">
</table>