### PR TITLE
Fix line wrapping when combining wide characters with eraseInLineFromCursor.

### DIFF
--- a/view.go
+++ b/view.go
@@ -680,7 +680,11 @@ func (v *View) parseInput(ch rune) (bool, []cell) {
 		if _, ok := v.ei.instruction.(eraseInLineFromCursor); ok {
 			// fill rest of line
 			v.ei.instructionRead()
-			repeatCount = v.InnerWidth() - v.wx
+			cx := 0
+			for _, cell := range v.lines[v.wy] {
+				cx += runewidth.RuneWidth(cell.chr)
+			}
+			repeatCount = v.InnerWidth() - cx
 			ch = ' '
 			moveCursor = false
 		} else if isEscape {


### PR DESCRIPTION
before:
<img width="755" alt="スクリーンショット 2021-11-30 20 17 10" src="https://user-images.githubusercontent.com/10097437/144046041-087ba087-fda3-4d49-98ff-b2a07b1f3839.png">

after:
<img width="705" alt="スクリーンショット 2021-11-30 21 11 07" src="https://user-images.githubusercontent.com/10097437/144046047-ec52d9fa-01a0-44b2-a311-ab4a698ca6b1.png">

@jesseduffield This patch is dirty, so I would like to hear your opinion.