### PR TITLE
fix escape codes

### DIFF
--- a/attribute.go
+++ b/attribute.go
@@ -31,7 +31,8 @@ const (
 )
 
 // Color attributes. These colors are compatible with tcell.Color type and can be expanded like:
-//  g.FgColor := gocui.Attribute(tcell.ColorLime)
+//
+//	g.FgColor := gocui.Attribute(tcell.ColorLime)
 const (
 	ColorBlack Attribute = AttrIsValidColor + iota
 	ColorRed

--- a/escape.go
+++ b/escape.go
@@ -211,7 +211,8 @@ func (ei *escapeInterpreter) parseOne(ch rune) (isEscape bool, err error) {
 }
 
 // outputNormal provides 8 different colors:
-//   black, red, green, yellow, blue, magenta, cyan, white
+//
+//	black, red, green, yellow, blue, magenta, cyan, white
 func (ei *escapeInterpreter) outputNormal() error {
 	for _, param := range ei.csiParam {
 		p, err := strconv.Atoi(param)
@@ -242,10 +243,11 @@ func (ei *escapeInterpreter) outputNormal() error {
 }
 
 // output256 allows you to leverage the 256-colors terminal mode:
-//   0x01 - 0x08: the 8 colors as in OutputNormal
-//   0x09 - 0x10: Color* | AttrBold
-//   0x11 - 0xe8: 216 different colors
-//   0xe9 - 0x1ff: 24 different shades of grey
+//
+//	0x01 - 0x08: the 8 colors as in OutputNormal
+//	0x09 - 0x10: Color* | AttrBold
+//	0x11 - 0xe8: 216 different colors
+//	0xe9 - 0x1ff: 24 different shades of grey
 func (ei *escapeInterpreter) output256() error {
 	if len(ei.csiParam) < 3 {
 		return ei.outputNormal()

--- a/escape.go
+++ b/escape.go
@@ -214,17 +214,17 @@ func (ei *escapeInterpreter) outputCSI() error {
 
 		skip := 1
 		switch {
-		case p == 0:
+		case p == 0: // reset style and color
 			ei.curFgColor = ColorDefault
 			ei.curBgColor = ColorDefault
-		case p >= 1 && p <= 9:
+		case p >= 1 && p <= 9: // set style
 			ei.curFgColor |= getFontEffect(p)
-		case p >= 21 && p <= 29:
+		case p >= 21 && p <= 29: // reset style
 			ei.curFgColor &= ^getFontEffect(p - 20)
-		case p >= 30 && p <= 37:
+		case p >= 30 && p <= 37: // set foreground color
 			ei.curFgColor &= AttrStyleBits
 			ei.curFgColor |= Get256Color(int32(p) - 30)
-		case p == setForegroundColor:
+		case p == setForegroundColor: // set foreground color (256-color or true color)
 			var color Attribute
 			var err error
 			color, skip, err = ei.csiColor(ei.csiParam[i:])
@@ -233,13 +233,13 @@ func (ei *escapeInterpreter) outputCSI() error {
 			}
 			ei.curFgColor &= AttrStyleBits
 			ei.curFgColor |= color
-		case p == defaultForegroundColor:
+		case p == defaultForegroundColor: // reset foreground color
 			ei.curFgColor &= AttrStyleBits
 			ei.curFgColor |= ColorDefault
-		case p >= 40 && p <= 47:
+		case p >= 40 && p <= 47: // set background color
 			ei.curBgColor &= AttrStyleBits
 			ei.curBgColor |= Get256Color(int32(p) - 40)
-		case p == setBackgroundColor:
+		case p == setBackgroundColor: // set background color (256-color or true color)
 			var color Attribute
 			var err error
 			color, skip, err = ei.csiColor(ei.csiParam[i:])
@@ -248,13 +248,13 @@ func (ei *escapeInterpreter) outputCSI() error {
 			}
 			ei.curBgColor &= AttrStyleBits
 			ei.curBgColor |= color
-		case p == defaultBackgroundColor:
+		case p == defaultBackgroundColor: // reset background color
 			ei.curBgColor &= AttrStyleBits
 			ei.curBgColor |= ColorDefault
-		case p >= 90 && p <= 97:
+		case p >= 90 && p <= 97: // set bright foreground color
 			ei.curFgColor &= AttrStyleBits
 			ei.curFgColor |= Get256Color(int32(p) - 90 + 8)
-		case p >= 100 && p <= 107:
+		case p >= 100 && p <= 107: // set bright background color
 			ei.curBgColor &= AttrStyleBits
 			ei.curBgColor |= Get256Color(int32(p) - 100 + 8)
 		default:

--- a/escape.go
+++ b/escape.go
@@ -42,15 +42,18 @@ const (
 	stateOSC
 	stateOSCEscape
 
-	bold               fontEffect = 1
-	faint              fontEffect = 2
-	italic             fontEffect = 3
-	underline          fontEffect = 4
-	blink              fontEffect = 5
-	reverse            fontEffect = 7
-	strike             fontEffect = 9
-	setForegroundColor fontEffect = 38
-	setBackgroundColor fontEffect = 48
+	bold      fontEffect = 1
+	faint     fontEffect = 2
+	italic    fontEffect = 3
+	underline fontEffect = 4
+	blink     fontEffect = 5
+	reverse   fontEffect = 7
+	strike    fontEffect = 9
+
+	setForegroundColor     int = 38
+	defaultForegroundColor int = 39
+	setBackgroundColor     int = 48
+	defaultBackgroundColor int = 49
 )
 
 var (
@@ -158,16 +161,7 @@ func (ei *escapeInterpreter) parseOne(ch rune) (isEscape bool, err error) {
 			ei.csiParam = append(ei.csiParam, "")
 			return true, nil
 		case ch == 'm':
-			var err error
-			switch ei.mode {
-			case OutputNormal:
-				err = ei.outputNormal()
-			case Output256:
-				err = ei.output256()
-			case OutputTrue:
-				err = ei.outputTrue()
-			}
-			if err != nil {
+			if err := ei.outputCSI(); err != nil {
 				return false, errCSIParseError
 			}
 
@@ -210,142 +204,122 @@ func (ei *escapeInterpreter) parseOne(ch rune) (isEscape bool, err error) {
 	return false, nil
 }
 
-// outputNormal provides 8 different colors:
-//
-//	black, red, green, yellow, blue, magenta, cyan, white
-func (ei *escapeInterpreter) outputNormal() error {
-	for _, param := range ei.csiParam {
-		p, err := strconv.Atoi(param)
+func (ei *escapeInterpreter) outputCSI() error {
+	n := len(ei.csiParam)
+	for i := 0; i < n; {
+		p, err := strconv.Atoi(ei.csiParam[i])
 		if err != nil {
 			return errCSIParseError
 		}
 
+		skip := 1
 		switch {
-		case p >= 30 && p <= 37:
-			ei.curFgColor = Get256Color(int32(p) - 30)
-		case p == 39:
-			ei.curFgColor = ColorDefault
-		case p >= 40 && p <= 47:
-			ei.curBgColor = Get256Color(int32(p) - 40)
-		case p == 49:
-			ei.curBgColor = ColorDefault
 		case p == 0:
 			ei.curFgColor = ColorDefault
 			ei.curBgColor = ColorDefault
+		case p >= 1 && p <= 9:
+			ei.curFgColor |= getFontEffect(p)
 		case p >= 21 && p <= 29:
 			ei.curFgColor &= ^getFontEffect(p - 20)
+		case p >= 30 && p <= 37:
+			ei.curFgColor &= AttrStyleBits
+			ei.curFgColor |= Get256Color(int32(p) - 30)
+		case p == setForegroundColor:
+			var color Attribute
+			var err error
+			color, skip, err = ei.csiColor(ei.csiParam[i:])
+			if err != nil {
+				return err
+			}
+			ei.curFgColor &= AttrStyleBits
+			ei.curFgColor |= color
+		case p == defaultForegroundColor:
+			ei.curFgColor &= AttrStyleBits
+			ei.curFgColor |= ColorDefault
+		case p >= 40 && p <= 47:
+			ei.curBgColor &= AttrStyleBits
+			ei.curBgColor |= Get256Color(int32(p) - 40)
+		case p == setBackgroundColor:
+			var color Attribute
+			var err error
+			color, skip, err = ei.csiColor(ei.csiParam[i:])
+			if err != nil {
+				return err
+			}
+			ei.curBgColor &= AttrStyleBits
+			ei.curBgColor |= color
+		case p == defaultBackgroundColor:
+			ei.curBgColor &= AttrStyleBits
+			ei.curBgColor |= ColorDefault
+		case p >= 90 && p <= 97:
+			ei.curFgColor &= AttrStyleBits
+			ei.curFgColor |= Get256Color(int32(p) - 90 + 8)
+		case p >= 100 && p <= 107:
+			ei.curBgColor &= AttrStyleBits
+			ei.curBgColor |= Get256Color(int32(p) - 100 + 8)
 		default:
-			ei.curFgColor |= getFontEffect(p)
 		}
+		i += skip
 	}
 
 	return nil
 }
 
-// output256 allows you to leverage the 256-colors terminal mode:
-//
-//	0x01 - 0x08: the 8 colors as in OutputNormal
-//	0x09 - 0x10: Color* | AttrBold
-//	0x11 - 0xe8: 216 different colors
-//	0xe9 - 0x1ff: 24 different shades of grey
-func (ei *escapeInterpreter) output256() error {
-	if len(ei.csiParam) < 3 {
-		return ei.outputNormal()
+func (ei *escapeInterpreter) csiColor(param []string) (color Attribute, skip int, err error) {
+	if len(param) < 2 {
+		err = errCSIParseError
+		return
 	}
 
-	mode, err := strconv.Atoi(ei.csiParam[1])
-	if err != nil {
-		return errCSIParseError
-	}
-	if mode != 5 {
-		return ei.outputNormal()
-	}
-
-	for _, param := range splitFgBg(ei.csiParam, 3) {
-		fgbg, err := strconv.Atoi(param[0])
+	switch param[1] {
+	case "2":
+		// 24-bit color
+		if ei.mode < OutputTrue {
+			err = errCSIParseError
+			return
+		}
+		if len(param) < 5 {
+			err = errCSIParseError
+			return
+		}
+		var red, green, blue int
+		red, err = strconv.Atoi(param[2])
 		if err != nil {
-			return errCSIParseError
+			err = errCSIParseError
+			return
 		}
-		color, err := strconv.Atoi(param[2])
+		green, err = strconv.Atoi(param[3])
 		if err != nil {
-			return errCSIParseError
+			err = errCSIParseError
+			return
 		}
-
-		switch fontEffect(fgbg) {
-		case setForegroundColor:
-			ei.curFgColor = Get256Color(int32(color))
-
-			for _, s := range param[3:] {
-				p, err := strconv.Atoi(s)
-				if err != nil {
-					return errCSIParseError
-				}
-
-				ei.curFgColor |= getFontEffect(p)
-			}
-		case setBackgroundColor:
-			ei.curBgColor = Get256Color(int32(color))
-		default:
-			return errCSIParseError
-		}
-	}
-	return nil
-}
-
-// outputTrue allows you to leverage the true-color terminal mode.
-//
-// Works with rgb ANSI sequence: `\x1b[38;2;<r>;<g>;<b>m`, `\x1b[48;2;<r>;<g>;<b>m`
-func (ei *escapeInterpreter) outputTrue() error {
-	if len(ei.csiParam) < 5 {
-		return ei.output256()
-	}
-
-	mode, err := strconv.Atoi(ei.csiParam[1])
-	if err != nil {
-		return errCSIParseError
-	}
-	if mode != 2 {
-		return ei.output256()
-	}
-
-	for _, param := range splitFgBg(ei.csiParam, 5) {
-		fgbg, err := strconv.Atoi(param[0])
+		blue, err = strconv.Atoi(param[4])
 		if err != nil {
-			return errCSIParseError
+			err = errCSIParseError
+			return
 		}
-		colr, err := strconv.Atoi(param[2])
+		return NewRGBColor(int32(red), int32(green), int32(blue)), 5, nil
+	case "5":
+		// 8-bit color
+		if ei.mode < Output256 {
+			err = errCSIParseError
+			return
+		}
+		if len(param) < 3 {
+			err = errCSIParseError
+			return
+		}
+		var hex int
+		hex, err = strconv.Atoi(param[2])
 		if err != nil {
-			return errCSIParseError
+			err = errCSIParseError
+			return
 		}
-		colg, err := strconv.Atoi(param[3])
-		if err != nil {
-			return errCSIParseError
-		}
-		colb, err := strconv.Atoi(param[4])
-		if err != nil {
-			return errCSIParseError
-		}
-		color := NewRGBColor(int32(colr), int32(colg), int32(colb))
-
-		switch fontEffect(fgbg) {
-		case setForegroundColor:
-			ei.curFgColor = color
-
-			for _, s := range param[5:] {
-				p, err := strconv.Atoi(s)
-				if err != nil {
-					return errCSIParseError
-				}
-
-				ei.curFgColor |= getFontEffect(p)
-			}
-		case setBackgroundColor:
-			ei.curBgColor = color
-		default:
-			return errCSIParseError
-		}
+		return Get256Color(int32(hex)), 3, nil
+	default:
+		err = errCSIParseError
+		return
 	}
-	return nil
 }
 
 // splitFgBg splits foreground and background color according to ANSI sequence.

--- a/escape_test.go
+++ b/escape_test.go
@@ -15,17 +15,17 @@ func TestParseOne(t *testing.T) {
 	assert.NoError(t, err)
 
 	ei = newEscapeInterpreter(OutputNormal)
-	parseEscRunes(t, ei, []rune{'\x1b', '[', '0', 'K'})
+	parseEscRunes(t, ei, "\x1b[0K")
 	_, ok := ei.instruction.(eraseInLineFromCursor)
 	assert.Equal(t, true, ok)
 
 	ei = newEscapeInterpreter(OutputNormal)
-	parseEscRunes(t, ei, []rune{'\x1b', '[', 'K'})
+	parseEscRunes(t, ei, "\x1b[K")
 	_, ok = ei.instruction.(eraseInLineFromCursor)
 	assert.Equal(t, true, ok)
 
 	ei = newEscapeInterpreter(OutputNormal)
-	parseEscRunes(t, ei, []rune{'\x1b', '[', '1', 'K'})
+	parseEscRunes(t, ei, "\x1b[1K")
 	_, ok = ei.instruction.(noInstruction)
 	assert.Equal(t, true, ok)
 
@@ -34,53 +34,76 @@ func TestParseOne(t *testing.T) {
 func TestParseOneColours(t *testing.T) {
 	scenarios := []struct {
 		outputMode OutputMode
-		runes      []rune
+		input      string
 		expectedFg Attribute
 		expectedBg Attribute
 	}{
-		{OutputNormal, []rune{'\x1b', '[', '3', '0', 'm'}, ColorBlack, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '1', 'm'}, ColorRed, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '2', 'm'}, ColorGreen, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '3', 'm'}, ColorYellow, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '4', 'm'}, ColorBlue, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '5', 'm'}, ColorMagenta, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '6', 'm'}, ColorCyan, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '3', '7', 'm'}, ColorWhite, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '4', '0', 'm'}, ColorDefault, ColorBlack},
-		{OutputNormal, []rune{'\x1b', '[', '4', '1', 'm'}, ColorDefault, ColorRed},
-		{OutputNormal, []rune{'\x1b', '[', '4', '2', 'm'}, ColorDefault, ColorGreen},
-		{OutputNormal, []rune{'\x1b', '[', '4', '3', 'm'}, ColorDefault, ColorYellow},
-		{OutputNormal, []rune{'\x1b', '[', '4', '4', 'm'}, ColorDefault, ColorBlue},
-		{OutputNormal, []rune{'\x1b', '[', '4', '5', 'm'}, ColorDefault, ColorMagenta},
-		{OutputNormal, []rune{'\x1b', '[', '4', '6', 'm'}, ColorDefault, ColorCyan},
-		{OutputNormal, []rune{'\x1b', '[', '4', '7', 'm'}, ColorDefault, ColorWhite},
-		{OutputNormal, []rune{'\x1b', '[', '4', '7', ';', '3', '1', 'm'}, ColorRed, ColorWhite},
+		{OutputNormal, "\x1b[30m", ColorBlack, ColorDefault},
+		{OutputNormal, "\x1b[31m", ColorRed, ColorDefault},
+		{OutputNormal, "\x1b[32m", ColorGreen, ColorDefault},
+		{OutputNormal, "\x1b[33m", ColorYellow, ColorDefault},
+		{OutputNormal, "\x1b[34m", ColorBlue, ColorDefault},
+		{OutputNormal, "\x1b[35m", ColorMagenta, ColorDefault},
+		{OutputNormal, "\x1b[36m", ColorCyan, ColorDefault},
+		{OutputNormal, "\x1b[37m", ColorWhite, ColorDefault},
+		{OutputNormal, "\x1b[40m", ColorDefault, ColorBlack},
+		{OutputNormal, "\x1b[41m", ColorDefault, ColorRed},
+		{OutputNormal, "\x1b[42m", ColorDefault, ColorGreen},
+		{OutputNormal, "\x1b[43m", ColorDefault, ColorYellow},
+		{OutputNormal, "\x1b[44m", ColorDefault, ColorBlue},
+		{OutputNormal, "\x1b[45m", ColorDefault, ColorMagenta},
+		{OutputNormal, "\x1b[46m", ColorDefault, ColorCyan},
+		{OutputNormal, "\x1b[47m", ColorDefault, ColorWhite},
+		{OutputNormal, "\x1b[47;31m", ColorRed, ColorWhite},
+		{OutputNormal, "\x1b[90m", Get256Color(8), ColorDefault},
+		{OutputNormal, "\x1b[91m", Get256Color(9), ColorDefault},
+		{OutputNormal, "\x1b[92m", Get256Color(10), ColorDefault},
+		{OutputNormal, "\x1b[93m", Get256Color(11), ColorDefault},
+		{OutputNormal, "\x1b[94m", Get256Color(12), ColorDefault},
+		{OutputNormal, "\x1b[95m", Get256Color(13), ColorDefault},
+		{OutputNormal, "\x1b[96m", Get256Color(14), ColorDefault},
+		{OutputNormal, "\x1b[97m", Get256Color(15), ColorDefault},
+		{OutputNormal, "\x1b[100m", ColorDefault, Get256Color(8)},
+		{OutputNormal, "\x1b[101m", ColorDefault, Get256Color(9)},
+		{OutputNormal, "\x1b[102m", ColorDefault, Get256Color(10)},
+		{OutputNormal, "\x1b[103m", ColorDefault, Get256Color(11)},
+		{OutputNormal, "\x1b[104m", ColorDefault, Get256Color(12)},
+		{OutputNormal, "\x1b[105m", ColorDefault, Get256Color(13)},
+		{OutputNormal, "\x1b[106m", ColorDefault, Get256Color(14)},
+		{OutputNormal, "\x1b[107m", ColorDefault, Get256Color(15)},
+		{Output256, "\x1b[38;5;32m", Get256Color(32), ColorDefault},
+		{OutputTrue, "\x1b[38;5;32m", Get256Color(32), ColorDefault},
+		{OutputTrue, "\x1b[38;2;50;103;205m", NewRGBColor(50, 103, 205), ColorDefault},
+		{Output256, "\x1b[48;5;32m", ColorDefault, Get256Color(32)},
+		{OutputTrue, "\x1b[48;5;32m", ColorDefault, Get256Color(32)},
+		{OutputTrue, "\x1b[48;2;50;103;205m", ColorDefault, NewRGBColor(50, 103, 205)},
+		{OutputTrue, "\x1b[1;95;48;2;255;224;224m", Get256Color(13), NewRGBColor(255, 224, 224)},
 	}
 
 	for _, scenario := range scenarios {
 		ei := newEscapeInterpreter(scenario.outputMode)
-		parseEscRunes(t, ei, scenario.runes)
-		assert.Equal(t, scenario.expectedFg, ei.curFgColor)
+		parseEscRunes(t, ei, scenario.input)
+		assert.Equal(t, scenario.expectedFg, ei.curFgColor&AttrColorBits)
 		assert.Equal(t, scenario.expectedBg, ei.curBgColor)
 	}
 
 	// resetting colours
 	scenarios = []struct {
 		outputMode OutputMode
-		runes      []rune
+		input      string
 		expectedFg Attribute
 		expectedBg Attribute
 	}{
-		{OutputNormal, []rune{'\x1b', '[', '3', '9', 'm'}, ColorDefault, ColorRed},
-		{OutputNormal, []rune{'\x1b', '[', '4', '9', 'm'}, ColorRed, ColorDefault},
-		{OutputNormal, []rune{'\x1b', '[', '0', 'm'}, ColorDefault, ColorDefault},
+		{OutputNormal, "\x1b[39m", ColorDefault, ColorRed},
+		{OutputNormal, "\x1b[49m", ColorRed, ColorDefault},
+		{OutputNormal, "\x1b[0m", ColorDefault, ColorDefault},
 	}
 
 	for _, scenario := range scenarios {
 		ei := newEscapeInterpreter(scenario.outputMode)
 		ei.curFgColor = ColorRed
 		ei.curBgColor = ColorRed
-		parseEscRunes(t, ei, scenario.runes)
+		parseEscRunes(t, ei, scenario.input)
 		assert.Equal(t, scenario.expectedFg, ei.curFgColor)
 		assert.Equal(t, scenario.expectedBg, ei.curBgColor)
 	}
@@ -88,28 +111,28 @@ func TestParseOneColours(t *testing.T) {
 	// setting attributes
 	attrScenarios := []struct {
 		outputMode   OutputMode
-		runes        []rune
+		input        string
 		expectedAttr Attribute
 	}{
-		{OutputNormal, []rune{'\x1b', '[', '1', 'm'}, AttrBold},
-		{OutputNormal, []rune{'\x1b', '[', '2', 'm'}, AttrDim},
-		{OutputNormal, []rune{'\x1b', '[', '3', 'm'}, AttrItalic},
-		{OutputNormal, []rune{'\x1b', '[', '4', 'm'}, AttrUnderline},
-		{OutputNormal, []rune{'\x1b', '[', '5', 'm'}, AttrBlink},
-		{OutputNormal, []rune{'\x1b', '[', '7', 'm'}, AttrReverse},
-		{OutputNormal, []rune{'\x1b', '[', '9', 'm'}, AttrStrikeThrough},
+		{OutputNormal, "\x1b[1m", AttrBold},
+		{OutputNormal, "\x1b[2m", AttrDim},
+		{OutputNormal, "\x1b[3m", AttrItalic},
+		{OutputNormal, "\x1b[4m", AttrUnderline},
+		{OutputNormal, "\x1b[5m", AttrBlink},
+		{OutputNormal, "\x1b[7m", AttrReverse},
+		{OutputNormal, "\x1b[9m", AttrStrikeThrough},
 	}
 
 	for _, scenario := range attrScenarios {
 		ei := newEscapeInterpreter(scenario.outputMode)
-		parseEscRunes(t, ei, scenario.runes)
-		isBold := ei.curFgColor&scenario.expectedAttr == scenario.expectedAttr
-		assert.Equal(t, true, isBold)
+		parseEscRunes(t, ei, scenario.input)
+		style := ei.curFgColor & AttrStyleBits
+		assert.Equal(t, scenario.expectedAttr, style)
 	}
 }
 
-func parseEscRunes(t *testing.T, ei *escapeInterpreter, runes []rune) {
-	for _, r := range runes {
+func parseEscRunes(t *testing.T, ei *escapeInterpreter, runes string) {
+	for _, r := range []rune(runes) {
 		isEscape, err := ei.parseOne(r)
 		assert.Equal(t, true, isEscape)
 		assert.NoError(t, err)

--- a/gui_others.go
+++ b/gui_others.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build !windows
 // +build !windows
 
 package gocui

--- a/gui_windows.go
+++ b/gui_windows.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build windows
 // +build windows
 
 package gocui


### PR DESCRIPTION
fix https://github.com/jesseduffield/lazygit/issues/1831

This is because escape codes such as `\e[1;95;48;2;255;224;224m` (`1`: bold, `95`: fg light magenta, `48;2;255;224;224`: bg `#ffe0e0`) cannot be interpreted.

```ini
# .gitconfig
[core]
    pager = delta
[delta]
    line-numbers = true
[diff]
	colorMoved = default
	colorMovedWS = allow-indentation-change
[color "diff"]
	; oldMoved = bold brightmagenta "#ffe0e0"
	; oldMovedAlternative = bold brightmagenta "#ffe0e0"
	oldMoved = bold brightmagenta brightblack
	oldMovedAlternative = bold brightmagenta brightblack
	newMoved = bold brightblue "#d0ffd0"
	newMovedAlternative = bold brightblue "#d0ffd0"
```

1. `git diff`:
<img width="1598" alt="tarminal-delta" src="https://user-images.githubusercontent.com/10097437/224029861-79702ca9-769f-4b35-9b93-3087a7a44a8b.png">

<table>
<tr>
	<td>before
	<td>after
<tr>
	<td>
<img width="954" alt="before-delta" src="https://user-images.githubusercontent.com/10097437/224030060-aa2fa9a6-fca2-4f13-a8dd-405400c1b821.png">
	<td>
<img width="1073" alt="after-delta" src="https://user-images.githubusercontent.com/10097437/224030082-76fb660a-bf76-4180-8f7a-dbfae24d7a68.png">
</table>

2. https://github.com/Ryooooooga/dotfiles/blob/942aa62f8d8d4e90ecf2fee8bd3bc0e26654f576/config/scripts/bin/color

<img width="529" alt="terminal-color" src="https://user-images.githubusercontent.com/10097437/224030662-36281d25-7b23-4977-80b7-91d8e09136df.png">

<table>
<tr>
	<td>before
	<td>after
<tr>
	<td><img width="1439" alt="before-color" src="https://user-images.githubusercontent.com/10097437/224030771-3cfa5b41-ec16-493e-941c-a6be4f2c1534.png">
	<td>
<img width="1599" alt="after-color" src="https://user-images.githubusercontent.com/10097437/224030835-e60b96b6-14e5-49fd-a1e9-d7986c0a18e7.png">
</table>