### PR TITLE
Added a formating function to text_area

### DIFF
--- a/text_area.go
+++ b/text_area.go
@@ -1,6 +1,8 @@
 package gocui
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/mattn/go-runewidth"
@@ -11,11 +13,15 @@ const (
 	WORD_SEPARATORS = "*?_+-.[]~=/&;!#$%^(){}<>"
 )
 
+var ErrNoFormater = errors.New("no formater found")
+
 type TextArea struct {
 	content   []rune
 	cursor    int
 	overwrite bool
 	clipboard string
+	// format the content by some injected rule
+	format func([]rune) ([]rune, error)
 }
 
 func (self *TextArea) TypeRune(r rune) {
@@ -246,6 +252,24 @@ func (self *TextArea) BackSpaceWord() {
 
 	self.clipboard = string(self.content[self.cursor:right])
 	self.content = append(self.content[:self.cursor], self.content[right:]...)
+}
+
+// Format the contents of the text area based on some rule. Will return ErrNoFormater
+// error if there is no formating rule set
+func (self *TextArea) Format() error {
+	if self.format == nil {
+		return ErrNoFormater
+	}
+	formatedContent, err := self.format(self.content)
+	if err != nil {
+		return fmt.Errorf("failed to format: %v", err)
+	}
+	self.content = formatedContent
+	return nil
+}
+
+func (self *TextArea) SetFormater(f func([]rune) ([]rune, error)) {
+	self.format = f
 }
 
 func (self *TextArea) Yank() {


### PR DESCRIPTION
This was needed to be added in order to implement formating according to the git 50/72 best practice for lazygit.

Pull request for 50/72 formating may be found here: https://github.com/jesseduffield/lazygit/pull/3095

It says [here](https://github.com/jesseduffield/lazygit/blob/master/CONTRIBUTING.md#updating-gocui) that the target branch should be "awesome", but I cannot find it. Deprecated documentation?