### PR TITLE
Fix a rendering regression introduced in #61

### DIFF
--- a/view.go
+++ b/view.go
@@ -1316,6 +1316,9 @@ func (v *View) LinesHeight() int {
 
 // ViewLinesHeight is the count of view lines (i.e. lines including wrapping)
 func (v *View) ViewLinesHeight() int {
+	v.writeMutex.Lock()
+	defer v.writeMutex.Unlock()
+
 	v.refreshViewLinesIfNeeded()
 	return len(v.viewLines)
 }


### PR DESCRIPTION
If ViewLinesHeight was called concurrently with drawing the view, the viewLines could be truncated.

Regression introduced in 3fd13166c9.