### PR TITLE
Make view geometry a little more sane

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -912,7 +912,7 @@ func calcScrollbarRune(
 }
 
 func calcRealScrollbarStartEnd(v *View) (bool, int, int) {
-	height := v.InnerHeight() + 1
+	height := v.InnerHeight()
 	fullHeight := v.ViewLinesHeight() - v.scrollMargin()
 
 	if v.CanScrollPastBottom {


### PR DESCRIPTION
This is a breaking change!

This fixes View.Size, Width and Height to be the correct (outer) size of a view including its frame, and InnerSize/InnerWidth/InnerHeight to be the usable client area exluding the frame. See commit message for details.

Reviewed as part of https://github.com/jesseduffield/lazygit/pull/4085.