### PR TITLE
Fix handling of `\n` wrt inserting null cells

### DIFF
--- a/view.go
+++ b/view.go
@@ -726,14 +726,6 @@ func (v *View) writeCells(x, y int, cells []cell) {
 	v.lines[y] = line[:newLen]
 }
 
-// readCell gets cell at specified location (x, y)
-func (v *View) readCell(x, y int) (cell, bool) {
-	if y < 0 || y >= len(v.lines) || x < 0 || x >= len(v.lines[y]) {
-		return cell{}, false
-	}
-	return v.lines[y][x], true
-}
-
 // Write appends a byte slice into the view's internal buffer. Because
 // View implements the io.Writer interface, it can be passed as parameter
 // of functions like fmt.Fprintf, fmt.Fprintln, io.Copy, etc. Clear must
@@ -764,7 +756,7 @@ func (v *View) writeRunes(p []rune) {
 
 	finishLine := func() {
 		v.autoRenderHyperlinksInCurrentLine()
-		if c, ok := v.readCell(v.wx, v.wy); !ok || c.chr == 0 {
+		if v.wx >= len(v.lines[v.wy]) {
 			v.writeCells(v.wx, v.wy, []cell{{
 				chr:     0,
 				fgColor: 0,

--- a/view.go
+++ b/view.go
@@ -690,7 +690,7 @@ func (v *View) makeWriteable(x, y int) {
 			v.lines = append(v.lines, nil)
 		}
 	}
-	// cell `x` must not be index-able (that's why `<`)
+	// cell `x` need not be index-able (that's why `<`)
 	// append should be used by `lines[y]` user if he wants to write beyond `x`
 	for len(v.lines[y]) < x {
 		if cap(v.lines[y]) > len(v.lines[y]) {

--- a/view.go
+++ b/view.go
@@ -762,31 +762,28 @@ func (v *View) writeRunes(p []rune) {
 	// Fill with empty cells, if writing outside current view buffer
 	v.makeWriteable(v.wx, v.wy)
 
+	finishLine := func() {
+		v.autoRenderHyperlinksInCurrentLine()
+		if c, ok := v.readCell(v.wx, v.wy); !ok || c.chr == 0 {
+			v.writeCells(v.wx, v.wy, []cell{{
+				chr:     0,
+				fgColor: 0,
+				bgColor: 0,
+			}})
+		}
+	}
+
 	for _, r := range p {
 		switch r {
 		case '\n':
-			v.autoRenderHyperlinksInCurrentLine()
-			if c, ok := v.readCell(v.wx, v.wy); !ok || c.chr == 0 {
-				v.writeCells(v.wx, v.wy, []cell{{
-					chr:     0,
-					fgColor: 0,
-					bgColor: 0,
-				}})
-			}
+			finishLine()
 			v.wx = 0
 			v.wy++
 			if v.wy >= len(v.lines) {
 				v.lines = append(v.lines, nil)
 			}
 		case '\r':
-			v.autoRenderHyperlinksInCurrentLine()
-			if c, ok := v.readCell(v.wx, v.wy); !ok || c.chr == 0 {
-				v.writeCells(v.wx, v.wy, []cell{{
-					chr:     0,
-					fgColor: 0,
-					bgColor: 0,
-				}})
-			}
+			finishLine()
 			v.wx = 0
 		default:
 			truncateLine, cells := v.parseInput(r, v.wx, v.wy)

--- a/view.go
+++ b/view.go
@@ -766,7 +766,7 @@ func (v *View) writeRunes(p []rune) {
 		switch r {
 		case '\n':
 			v.autoRenderHyperlinksInCurrentLine()
-			if c, ok := v.readCell(v.wx+1, v.wy); !ok || c.chr == 0 {
+			if c, ok := v.readCell(v.wx, v.wy); !ok || c.chr == 0 {
 				v.writeCells(v.wx, v.wy, []cell{{
 					chr:     0,
 					fgColor: 0,

--- a/view_test.go
+++ b/view_test.go
@@ -39,10 +39,7 @@ func TestWriteRunes(t *testing.T) {
 		{
 			[]string{"ab"},
 			"1\n",
-			/* EXPECTED:
 			[]string{"1b", ""},
-			ACTUAL: */
-			[]string{"1\x00", ""},
 		},
 		{
 			[]string{"abc"},


### PR DESCRIPTION
This fixes a theoretical problem with overwriting existing lines where a line is exactly one character longer than what's being written; in this case we overwrite the existing character with a null character.

This is only a theoretical problem because to my knowledge we don't overwrite existing text anywhere, at least not in lazygit. The motivation of this PR was not so much to fix the bug, but to simplify the code; this makes it easier to put [this PR](https://github.com/jesseduffield/gocui/pull/69) on top of it.