### PR TITLE
Only avoid the blank line at end of view if view is not editable

### DIFF
--- a/view.go
+++ b/view.go
@@ -787,7 +787,7 @@ func (v *View) writeRunes(p []rune) {
 	}
 
 	until := len(p)
-	if until > 0 && p[until-1] == '\n' {
+	if !v.Editable && until > 0 && p[until-1] == '\n' {
 		v.pendingNewline = true
 		until--
 	}


### PR DESCRIPTION
Reviewed as part of https://github.com/jesseduffield/lazygit/pull/4182.