### PR TITLE
Use black as the foreground color for highlighted search results

### DIFF
--- a/view.go
+++ b/view.go
@@ -523,6 +523,7 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) {
 	}
 
 	if matched, selected := v.isPatternMatchedRune(x, y); matched {
+		fgColor = ColorBlack
 		if selected {
 			bgColor = ColorCyan
 		} else {


### PR DESCRIPTION
White text is hard to read on a cyan or yellow background, so using black improves contrast.

Fixes https://github.com/jesseduffield/lazygit/issues/4162.