### PR TITLE
Remove Project Gutenberg header to make the file free

### DIFF
--- a/_examples/Mark.Twain-Tom.Sawyer.txt
+++ b/_examples/Mark.Twain-Tom.Sawyer.txt
@@ -1,27 +1,3 @@
-The Project Gutenberg EBook of The Adventures of Tom Sawyer, Complete
-by Mark Twain (Samuel Clemens)
-
-This eBook is for the use of anyone anywhere at no cost and with
-almost no restrictions whatsoever.  You may copy it, give it away or
-re-use it under the terms of the Project Gutenberg License included
-with this eBook or online at www.gutenberg.net
-
-
-Title: The Adventures of Tom Sawyer, Complete
-
-Author: Mark Twain (Samuel Clemens)
-
-Release Date: August 20, 2006 [EBook #74]
-[Last updated: May 3, 2011]
-
-Language: English
-
-
-*** START OF THIS PROJECT GUTENBERG EBOOK TOM SAWYER ***
-
-
-
-
 Produced by David Widger. The previous edition was updated by Jose
 Menendez.
 


### PR DESCRIPTION
Dear maintainers,

About the testdata [_examples/Mark.Twain-Tom.Sawyer.txt](https://github.com/jesseduffield/gocui/blob/master/_examples/Mark.Twain-Tom.Sawyer.txt),

The original text of "The Adventures of Tom Sawyer" by Mark Twain is in the public domain.

However, the eBook version from Project Gutenberg is **non-free due to restrictions on commercial use**, specifically clauses 1.E.7, 1.E.8, and 1.E.9 of the Project Gutenberg License.

To make this file free, this commit **removes all references to the Project Gutenberg**, in accordance with clause 1.C of the Project Gutenberg License.

Full text of the Project Gutenberg License:

* https://www.gutenberg.org/policy/license.html#the-full-project-gutenberg-license-in-legalese-normative

Legal references:

* https://lists.debian.org/debian-legal/2025/03/msg00004.html
* https://lists.debian.org/debian-devel/2025/03/msg00229.html
* https://lists.debian.org/debian-legal/2017/08/msg00001.html