### PR TITLE
Render hyperlinks in last line of view if it doesn't end with a line feed

### DIFF
--- a/view.go
+++ b/view.go
@@ -822,6 +822,8 @@ func (v *View) writeRunes(p []rune) {
 
 	if v.pendingNewline {
 		finishLine()
+	} else {
+		v.autoRenderHyperlinksInCurrentLine()
 	}
 
 	v.updateSearchPositions()

--- a/view_test.go
+++ b/view_test.go
@@ -117,6 +117,27 @@ func TestUpdatedCursorAndOrigin(t *testing.T) {
 	}
 }
 
+func TestAutoRenderingHyperlinks(t *testing.T) {
+	v := NewView("name", 0, 0, 10, 10, OutputNormal)
+	v.AutoRenderHyperLinks = true
+
+	v.writeRunes([]rune("htt"))
+	// No hyperlinks are generated for incomplete URLs
+	assert.Equal(t, "", v.lines[0][0].hyperlink)
+	// Writing more characters to the same line makes the link complete (even
+	// though we didn't see a newline yet)
+	v.writeRunes([]rune("ps://example.com"))
+	assert.Equal(t, "https://example.com", v.lines[0][0].hyperlink)
+
+	v.Clear()
+	// Valid but incomplete URL
+	v.writeRunes([]rune("https://exa"))
+	assert.Equal(t, "https://exa", v.lines[0][0].hyperlink)
+	// Writing more characters to the same fixes the link
+	v.writeRunes([]rune("mple.com"))
+	assert.Equal(t, "https://example.com", v.lines[0][0].hyperlink)
+}
+
 func TestContainsColoredText(t *testing.T) {
 	hexColor := func(text string, hexStr string) []cell {
 		cells := make([]cell, len(text))


### PR DESCRIPTION
Previously we would render hyperlinks only when seeing a newline; but for some views, the last line doesn't end in a newline (e.g. lazygit's confirmation panels), so hyperlinks were never rendered in the last line for those.