### PR TITLE
Make highlight overwrite the background color

### DIFF
--- a/view.go
+++ b/view.go
@@ -519,9 +519,9 @@ func (v *View) setRune(x, y int, ch rune, fgColor, bgColor Attribute) {
 			}
 			fgColor = fgColor | AttrBold
 			if v.HighlightInactive {
-				bgColor = bgColor | v.InactiveViewSelBgColor
+				bgColor = (bgColor & AttrStyleBits) | v.InactiveViewSelBgColor
 			} else {
-				bgColor = bgColor | v.SelBgColor
+				bgColor = (bgColor & AttrStyleBits) | v.SelBgColor
 			}
 		}
 	}


### PR DESCRIPTION
It seems that highlighting has so far only been used in cases where there wasn't a background color. Or'ing the bits of the color with the existing background color doesn't make sense.

Reviewed as part of https://github.com/jesseduffield/lazygit/pull/4429.