### PR TITLE
Allow chaining of focus-specific and non-focus-specific mouse bindings

### DIFF
--- a/gui.go
+++ b/gui.go
@@ -1428,7 +1428,9 @@ func (g *Gui) execMouseKeybindings(view *View, ev *GocuiEvent, opts ViewMouseBin
 	// first pass looks for ones that match the focused view
 	for _, binding := range g.viewMouseBindings {
 		if isMatch(binding) && binding.FocusedView != "" && binding.FocusedView == g.currentView.Name() {
-			return true, binding.Handler(opts)
+			if err := binding.Handler(opts); !errors.Is(err, ErrKeybindingNotHandled) {
+				return true, err
+			}
 		}
 	}
 


### PR DESCRIPTION
Similar to what we did for key bindings in 5e9bd664590f, this allows focus-specific mouse handlers to pass dispatching on to a handler that is not focus-specific.