### PR TITLE
Fixing errors in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ package main
 import (
 	"fmt"
 	"log"
+	"errors"
 
 	"github.com/awesome-gocui/gocui"
 )
@@ -81,7 +82,7 @@ func main() {
 		log.Panicln(err)
 	}
 
-	if err := g.MainLoop(); err != nil && !gocui.IsQuit(err) {
+	if err := g.MainLoop(); err != nil && !errors.Is(err, gocui.ErrQuit) {
 		log.Panicln(err)
 	}
 }
@@ -89,7 +90,7 @@ func main() {
 func layout(g *gocui.Gui) error {
 	maxX, maxY := g.Size()
 	if v, err := g.SetView("hello", maxX/2-7, maxY/2, maxX/2+7, maxY/2+2, 0); err != nil {
-		if !gocui.IsUnknownView(err) {
+		if !errors.Is(err, gocui.ErrUnknownView) {
 			return err
 		}
 


### PR DESCRIPTION
the error was in  `gocui.IsQuit(err)`  and  `gocui.IsUnknownView(err)` since they have replaced with  `errors.Is(err, gocui.ErrQuit)` , `errors.Is(err, gocui.ErrUnknownView)`