### PR TITLE
Feature: ctrl+arrow jump support

### DIFF
--- a/edit.go
+++ b/edit.go
@@ -30,6 +30,8 @@ func SimpleEditor(v *View, key Key, ch rune, mod Modifier) bool {
 		v.TextArea.BackSpaceWord()
 	case key == KeyBackspace || key == KeyBackspace2 || key == KeyCtrlH:
 		v.TextArea.BackSpaceChar()
+	case key == KeyDelete && (mod&ModAlt) != 0:
+		v.TextArea.DeleteWord()
 	case key == KeyCtrlD || key == KeyDelete:
 		v.TextArea.DeleteChar()
 	case key == KeyArrowDown:

--- a/edit.go
+++ b/edit.go
@@ -40,10 +40,14 @@ func SimpleEditor(v *View, key Key, ch rune, mod Modifier) bool {
 		v.TextArea.MoveLeftWord()
 	case key == KeyArrowLeft || key == KeyCtrlB:
 		v.TextArea.MoveCursorLeft()
+	case key == KeyCtrlArrowLeft:
+		v.TextArea.MoveLeftWord()
 	case (key == KeyArrowRight || ch == 'f') && (mod&ModAlt) != 0:
 		v.TextArea.MoveRightWord()
 	case key == KeyArrowRight || key == KeyCtrlF:
 		v.TextArea.MoveCursorRight()
+	case key == KeyCtrlArrowRight:
+		v.TextArea.MoveRightWord()
 	case key == KeyEnter:
 		v.TextArea.TypeCharacter("\n")
 	case key == KeySpace:

--- a/edit.go
+++ b/edit.go
@@ -64,6 +64,10 @@ func SimpleEditor(v *View, key Key, ch rune, mod Modifier) bool {
 		v.TextArea.GoToEndOfLine()
 	case key == KeyCtrlW:
 		v.TextArea.BackSpaceWord()
+	case key == KeyCtrlBackspace:
+		v.TextArea.BackSpaceWord()
+	case key == KeyCtrlDelete:
+		v.TextArea.DeleteWord()
 	case key == KeyCtrlY:
 		v.TextArea.Yank()
 	case ch != 0:

--- a/keybinding.go
+++ b/keybinding.go
@@ -229,6 +229,10 @@ const (
 	KeyShiftArrowDown     = Key(tcell.KeyF63)
 	KeyArrowLeft          = Key(tcell.KeyLeft)
 	KeyArrowRight         = Key(tcell.KeyRight)
+	KeyCtrlArrowLeft      = Key(tcell.KeyF52)
+	KeyCtrlArrowRight     = Key(tcell.KeyF53)
+	KeyCtrlArrowUp        = Key(tcell.KeyF54)
+	KeyCtrlArrowDown      = Key(tcell.KeyF55)
 )
 
 // Keys combinations.

--- a/keybinding.go
+++ b/keybinding.go
@@ -233,6 +233,8 @@ const (
 	KeyCtrlArrowRight     = Key(tcell.KeyF53)
 	KeyCtrlArrowUp        = Key(tcell.KeyF54)
 	KeyCtrlArrowDown      = Key(tcell.KeyF55)
+	KeyCtrlBackspace      = Key(tcell.KeyF56)
+	KeyCtrlDelete         = Key(tcell.KeyF57)
 )
 
 // Keys combinations.

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -327,6 +327,14 @@ func (g *Gui) pollEvent() GocuiEvent {
 			mod = 0
 			ch = rune(0)
 			k = tcell.KeyF55
+		} else if mod == tcell.ModCtrl && k == tcell.KeyBackspace {
+			mod = 0
+			ch = rune(0)
+			k = tcell.KeyF56
+		} else if mod == tcell.ModCtrl && k == tcell.KeyDelete {
+			mod = 0
+			ch = rune(0)
+			k = tcell.KeyF57
 		} else if mod == tcell.ModCtrl || mod == tcell.ModShift {
 			// remove Ctrl or Shift if specified
 			// - shift - will be translated to the final code of rune

--- a/tcell_driver.go
+++ b/tcell_driver.go
@@ -311,6 +311,22 @@ func (g *Gui) pollEvent() GocuiEvent {
 			mod = 0
 			ch = rune(0)
 			k = tcell.KeyF63
+		} else if mod == tcell.ModCtrl && k == tcell.KeyLeft {
+			mod = 0
+			ch = rune(0)
+			k = tcell.KeyF52
+		} else if mod == tcell.ModCtrl && k == tcell.KeyRight {
+			mod = 0
+			ch = rune(0)
+			k = tcell.KeyF53
+		} else if mod == tcell.ModCtrl && k == tcell.KeyUp {
+			mod = 0
+			ch = rune(0)
+			k = tcell.KeyF54
+		} else if mod == tcell.ModCtrl && k == tcell.KeyDown {
+			mod = 0
+			ch = rune(0)
+			k = tcell.KeyF55
 		} else if mod == tcell.ModCtrl || mod == tcell.ModShift {
 			// remove Ctrl or Shift if specified
 			// - shift - will be translated to the final code of rune

--- a/text_area.go
+++ b/text_area.go
@@ -341,12 +341,15 @@ func (self *TextArea) MoveLeftWord() {
 }
 
 func (self *TextArea) MoveRightWord() {
+	self.cursor = self.newCursorForMoveRightWord()
+}
+
+func (self *TextArea) newCursorForMoveRightWord() int {
 	if self.atEnd() {
-		return
+		return self.cursor
 	}
 	if self.atLineEnd() {
-		self.cursor++
-		return
+		return self.cursor + 1
 	}
 
 	cellCursor := self.contentCursorToCellCursor(self.cursor)
@@ -364,7 +367,7 @@ func (self *TextArea) MoveRightWord() {
 		}
 	}
 
-	self.cursor = self.cellCursorToContentCursor(cellCursor)
+	return self.cellCursorToContentCursor(cellCursor)
 }
 
 func (self *TextArea) MoveCursorUp() {
@@ -556,6 +559,20 @@ func (self *TextArea) BackSpaceWord() {
 	}
 	self.content = self.content[:newCursor] + self.content[self.cursor:]
 	self.cursor = newCursor
+	self.updateCells()
+}
+
+func (self *TextArea) DeleteWord() {
+	newCursor := self.newCursorForMoveRightWord()
+	if newCursor == self.cursor {
+		return
+	}
+
+	clipboard := self.content[self.cursor:newCursor]
+	if clipboard != "\n" {
+		self.clipboard = clipboard
+	}
+	self.content = self.content[:self.cursor] + self.content[newCursor:]
 	self.updateCells()
 }
 


### PR DESCRIPTION
## Improved text editintg
Adds common keybinds from windows and linux allowing for easier editing in text areas.  
Closing both [#5227](https://github.com/jesseduffield/lazygit/issues/5227) and [#3353](https://github.com/jesseduffield/lazygit/issues/3353) from lazygit

This pr doesn't affect any of the existing mac behaviour.  

Added Control:
| Binding | Action |
|--------|--------|
| Ctrl+ArrowLeft | Jump word left |
| Ctrl+ArrowRight | Jump word right |
| Ctrl+Backspace | Backspace word |
| Ctrl+Delete | Delete Word | 